### PR TITLE
Display WaveForm while playing in second screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ playground.xcworkspace
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
 #
 Pods/
+Podfile.lock
 
 # Carthage
 #

--- a/VoiceRecorder/Controller/PlayVoiceViewController.swift
+++ b/VoiceRecorder/Controller/PlayVoiceViewController.swift
@@ -14,30 +14,16 @@ class PlayVoiceViewController: UIViewController {
     var playVoiceViewModel : PlayVoiceViewModel!
     var firebaseStorageManager : FirebaseStorageManager!
     
-    var currentPositionView : UIView = {
-        let currentPositionView = UIView()
-        currentPositionView.translatesAutoresizingMaskIntoConstraints = false
-        let screenRect = UIScreen.main.bounds
-        currentPositionView.frame.size.width = screenRect.size.width
-        currentPositionView.frame.size.height = screenRect.size.height * (0.15)
-        let path = UIBezierPath()
-        path.move(to: CGPoint(x: 0, y: 0))
-        path.addLine(to: CGPoint(x: 0, y: currentPositionView.frame.height))
-        let shape = CAShapeLayer()
-        shape.path = path.cgPath
-        shape.strokeColor = UIColor.black.cgColor
-        shape.fillColor = UIColor.clear.cgColor
-        shape.lineWidth = screenRect.size.width/112/10
-        currentPositionView.layer.addSublayer(shape)
-        return currentPositionView
+    var verticalLineView : VerticalLineView = {
+        let verticalLineView = VerticalLineView()
+        verticalLineView.translatesAutoresizingMaskIntoConstraints = false
+        return verticalLineView
     }()
     
-    var soundWaveImageView : UIImageView = {
-        let soundWaveImageView = UIImageView()
-        soundWaveImageView.translatesAutoresizingMaskIntoConstraints = false
-        soundWaveImageView.frame.size.width = CGFloat(FP_INFINITE)
-        soundWaveImageView.contentMode = .left
-        return soundWaveImageView
+    var waveFormImageView : WaveFormImageView = {
+        let waveFormImageView = WaveFormImageView(frame: CGRect())
+        waveFormImageView.translatesAutoresizingMaskIntoConstraints = false
+        return waveFormImageView
     }()
     
     var selectedPitchSegment : UISegmentedControl = {
@@ -118,8 +104,8 @@ class PlayVoiceViewController: UIViewController {
     
     func setView(){
         self.view.addSubview(fileNameLabel)
-        self.view.addSubview(currentPositionView)
-        self.view.addSubview(soundWaveImageView)
+        self.view.addSubview(verticalLineView)
+        self.view.addSubview(waveFormImageView)
         self.view.addSubview(selectedPitchSegment)
         self.view.addSubview(volumeTextLabel)
         self.view.addSubview(volumeSlider)
@@ -135,18 +121,18 @@ class PlayVoiceViewController: UIViewController {
             fileNameLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             fileNameLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 30),
             
-            soundWaveImageView.leadingAnchor.constraint(equalTo: view.centerXAnchor),
-            soundWaveImageView.topAnchor.constraint(equalTo: fileNameLabel.bottomAnchor, constant: 30),
-            soundWaveImageView.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.15),
-            soundWaveImageView.widthAnchor.constraint(equalTo: view.widthAnchor),
+            waveFormImageView.leadingAnchor.constraint(equalTo: view.centerXAnchor),
+            waveFormImageView.topAnchor.constraint(equalTo: fileNameLabel.bottomAnchor, constant: 30),
+            waveFormImageView.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.15),
+            waveFormImageView.widthAnchor.constraint(equalTo: view.widthAnchor),
             
-            currentPositionView.leadingAnchor.constraint(equalTo: view.centerXAnchor),
-            currentPositionView.topAnchor.constraint(equalTo: fileNameLabel.bottomAnchor, constant: 30),
-            currentPositionView.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.15),
-            currentPositionView.widthAnchor.constraint(equalTo: view.widthAnchor),
+            verticalLineView.leadingAnchor.constraint(equalTo: view.centerXAnchor),
+            verticalLineView.topAnchor.constraint(equalTo: fileNameLabel.bottomAnchor, constant: 30),
+            verticalLineView.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.15),
+            verticalLineView.widthAnchor.constraint(equalTo: view.widthAnchor),
             
             selectedPitchSegment.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            selectedPitchSegment.topAnchor.constraint(equalTo: soundWaveImageView.bottomAnchor, constant: 30),
+            selectedPitchSegment.topAnchor.constraint(equalTo: waveFormImageView.bottomAnchor, constant: 30),
             
             volumeTextLabel.topAnchor.constraint(equalTo: selectedPitchSegment.bottomAnchor, constant: 30),
             volumeTextLabel.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: 0.8),
@@ -160,7 +146,7 @@ class PlayVoiceViewController: UIViewController {
             playAndPauseButton.centerYAnchor.constraint(equalTo: volumeSlider.bottomAnchor, constant: 30),
                         
         ])
-        view.bringSubviewToFront(currentPositionView)
+        view.bringSubviewToFront(verticalLineView)
     }
     
     func setUIText(){
@@ -206,7 +192,7 @@ class PlayVoiceViewController: UIViewController {
 
 extension PlayVoiceViewController : FirebaseStorageManagerDelegate{
     func downloadComplete(url : URL) {
-        soundWaveImageView.load(url: url) {
+        waveFormImageView.load(url: url) {
             self.playAndPauseButton.isEnabled = true
         }
         playVoiceManager = PlayVoiceManager()
@@ -225,8 +211,8 @@ extension PlayVoiceViewController : PlayVoiceDelegate{
     
     func displayWaveForm(to currentPosition : AVAudioFramePosition, in audioLengthSamples : AVAudioFramePosition) {
         print("currentPosition: \(currentPosition), audioLengthSamples: \(audioLengthSamples)")
-        let newX = (self.soundWaveImageView.image?.size.width ?? 0) * CGFloat(currentPosition) / CGFloat(audioLengthSamples)
-        self.soundWaveImageView.transform = CGAffineTransform(translationX: -newX, y: 0)
+        let newX = (self.waveFormImageView.image?.size.width ?? 0) * CGFloat(currentPosition) / CGFloat(audioLengthSamples)
+        self.waveFormImageView.transform = CGAffineTransform(translationX: -newX, y: 0)
     }
 }
 

--- a/VoiceRecorder/Controller/RecordVoiceViewController.swift
+++ b/VoiceRecorder/Controller/RecordVoiceViewController.swift
@@ -21,11 +21,23 @@ class RecordVoiceViewController: UIViewController {
     var audioSessionManager = AudioSessionManager()
     var isHour = false
         
-    let waveFormView : UIView = {
-        let waveFormView = UIView()
-        waveFormView.translatesAutoresizingMaskIntoConstraints = false
-        waveFormView.frame.size.width = CGFloat(FP_INFINITE)
-        return waveFormView
+    let waveFormCanvasView : UIView = {
+        let waveFormCanvasView = UIView()
+        waveFormCanvasView.translatesAutoresizingMaskIntoConstraints = false
+        waveFormCanvasView.frame.size.width = CGFloat(FP_INFINITE)
+        return waveFormCanvasView
+    }()
+    
+    var verticalLineView : VerticalLineView = {
+        let verticalLineView = VerticalLineView()
+        verticalLineView.translatesAutoresizingMaskIntoConstraints = false
+        return verticalLineView
+    }()
+    
+    let waveFormImageView : WaveFormImageView = {
+        let waveFormImageView = WaveFormImageView(frame: CGRect())
+        waveFormImageView.translatesAutoresizingMaskIntoConstraints = false
+        return waveFormImageView
     }()
     
     let frequencyLabel : UILabel = {
@@ -107,7 +119,7 @@ class RecordVoiceViewController: UIViewController {
             if !isHour{
                 time = time[0..<5]
             }
-            drawWaveFormManager.stopDrawing(in: waveFormView)
+            drawWaveFormManager.stopDrawing(in: waveFormCanvasView)
             recordVoiceManager.stopRecording(time: time) {
                 self.delegate?.updateList()
                 self.playVoiceManager.setNewScheduleFile()
@@ -118,7 +130,7 @@ class RecordVoiceViewController: UIViewController {
             print("recording stop")
         } else {
             recordVoiceManager.startRecording()
-            drawWaveFormManager.startDrawing(of: recordVoiceManager.recorder!, in: waveFormView)
+            drawWaveFormManager.startDrawing(of: recordVoiceManager.recorder!, in: waveFormCanvasView)
             record_start_stop_button.setImage(UIImage(systemName: "stop.fill"), for: .normal)
             record_start_stop_button.tintColor = .black
             setUIBeforeRecording()
@@ -143,7 +155,7 @@ class RecordVoiceViewController: UIViewController {
     }
     
     func setView() {
-        self.view.addSubview(waveFormView)
+        self.view.addSubview(waveFormCanvasView)
         
         self.view.addSubview(frequencyLabel)
         self.view.addSubview(frequencySlider)
@@ -162,11 +174,11 @@ class RecordVoiceViewController: UIViewController {
     
     func autoLayout() {
         NSLayoutConstraint.activate([
-            waveFormView.topAnchor.constraint(equalToSystemSpacingBelow: self.view.topAnchor, multiplier: 10),
-            waveFormView.widthAnchor.constraint(equalTo: self.view.widthAnchor),
-            waveFormView.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: 0.15),
+            waveFormCanvasView.topAnchor.constraint(equalToSystemSpacingBelow: self.view.topAnchor, multiplier: 10),
+            waveFormCanvasView.widthAnchor.constraint(equalTo: self.view.widthAnchor),
+            waveFormCanvasView.heightAnchor.constraint(equalTo: self.view.heightAnchor, multiplier: 0.15),
             
-            frequencyLabel.topAnchor.constraint(equalToSystemSpacingBelow: waveFormView.bottomAnchor, multiplier: 2),
+            frequencyLabel.topAnchor.constraint(equalToSystemSpacingBelow: waveFormCanvasView.bottomAnchor, multiplier: 2),
             frequencyLabel.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: 0.8),
             frequencyLabel.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
             
@@ -179,7 +191,7 @@ class RecordVoiceViewController: UIViewController {
             
             buttonStackView.topAnchor.constraint(equalTo: progressTimeLabel.bottomAnchor, constant: 30),
 //            buttonStackView.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: 0.8),
-//            buttonStackView.heightAnchor.constraint(equalTo: waveFormView.heightAnchor, multiplier: 0.9),
+//            buttonStackView.heightAnchor.constraint(equalTo: waveFormCanvasView.heightAnchor, multiplier: 0.9),
             buttonStackView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
             
 //            record_start_stop_button.heightAnchor.constraint(equalTo: buttonStackView.heightAnchor),
@@ -202,7 +214,7 @@ class RecordVoiceViewController: UIViewController {
     override func viewDidDisappear(_ animated: Bool) {
         if recordVoiceManager.isRecording(){
             recordVoiceManager.stopRecording(time: progressTimeLabel.text!) {
-                self.drawWaveFormManager.stopDrawing(in: self.waveFormView)
+                self.drawWaveFormManager.stopDrawing(in: self.waveFormCanvasView)
                 self.delegate?.updateList()
             }
         }
@@ -243,12 +255,12 @@ extension RecordVoiceViewController : DrawWaveFormManagerDelegate {
     func moveWaveFormView(_ step: CGFloat) {
         
         UIView.animate(withDuration: 1/14, animations: {
-            self.waveFormView.transform = CGAffineTransform(translationX: -step, y: 0)
+            self.waveFormCanvasView.transform = CGAffineTransform(translationX: -step, y: 0)
         })
     }
     
     func resetWaveFormView() {
-        self.waveFormView.transform = CGAffineTransform(translationX: 0, y: 0)
+        self.waveFormCanvasView.transform = CGAffineTransform(translationX: 0, y: 0)
     }
 }
 

--- a/VoiceRecorder/Controller/RecordVoiceViewController.swift
+++ b/VoiceRecorder/Controller/RecordVoiceViewController.swift
@@ -243,6 +243,8 @@ class RecordVoiceViewController: UIViewController {
         case .afterRecording:
             recordFile_ButtonStackView.isHidden = false
             frequencySlider.isHidden = false
+            waveFormImageView.image = drawWaveFormManager.getWaveFormImage()
+            recordFile_play_PauseButton.setImage(UIImage(systemName: "play"), for: .normal)
         case .beforePlaying:
             waveFormCanvasView.isHidden = true
             waveFormImageView.isHidden = false
@@ -300,7 +302,8 @@ extension RecordVoiceViewController : RecordVoiceManagerDelegate {
 
 extension RecordVoiceViewController : PlayVoiceDelegate{
     func displayWaveForm(to currentPosition: AVAudioFramePosition, in audioLengthSamples: AVAudioFramePosition) {
-        //
+        let newX = (self.waveFormImageView.image?.size.width ?? 0) * CGFloat(currentPosition) / CGFloat(audioLengthSamples)
+        self.waveFormImageView.transform = CGAffineTransform(translationX: -newX, y: 0)
     }
     
     func playEndTime() {

--- a/VoiceRecorder/Manager/DrawWaveFormManager.swift
+++ b/VoiceRecorder/Manager/DrawWaveFormManager.swift
@@ -21,6 +21,7 @@ class DrawWaveFormManager{
     private var jump : CGFloat!
     private var waveLayer : CAShapeLayer!
     private var traitLength : CGFloat!
+    private var waveFormImage : UIImage!
     private var start : CGPoint!
     private var step : CGFloat!
     
@@ -46,10 +47,10 @@ class DrawWaveFormManager{
         })
     }
     
-    func stopDrawing(in view : UIView){
+    func stopDrawing(in view : UIView) {
         timer.invalidate()
-        saveImageInLocal(getUIImage(from: view))
-        // 파일 업로드
+        waveFormImage = getUIImage(from: view)
+        saveImageInLocal(waveFormImage)
     }
     
     func removeWaveForm() {
@@ -121,5 +122,9 @@ class DrawWaveFormManager{
         catch {
             print("error - saveImageInLocal")
         }
+    }
+    
+    func getWaveFormImage() -> UIImage {
+        return waveFormImage
     }
 }

--- a/VoiceRecorder/View/VerticalLineView.swift
+++ b/VoiceRecorder/View/VerticalLineView.swift
@@ -8,13 +8,34 @@
 import UIKit
 
 class VerticalLineView: UIView {
-
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+    
+    private var path: UIBezierPath!
+    private var shape: CAShapeLayer!
+    private var screenRect : CGRect!
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
     }
-    */
-
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func draw(_ rect: CGRect) {
+        screenRect = UIScreen.main.bounds
+        self.frame.size.width = screenRect.size.width
+        self.frame.size.height = screenRect.size.height * (0.15)
+        
+        path = UIBezierPath()
+        path.move(to: CGPoint(x: 0, y: 0))
+        path.addLine(to: CGPoint(x: 0, y: self.frame.height))
+        
+        shape = CAShapeLayer()
+        shape.path = path.cgPath
+        shape.strokeColor = UIColor.black.cgColor
+        shape.fillColor = UIColor.clear.cgColor
+        shape.lineWidth = screenRect.size.width/112/10
+        
+        self.layer.addSublayer(shape)
+    }
 }

--- a/VoiceRecorder/View/WaveFormImageView.swift
+++ b/VoiceRecorder/View/WaveFormImageView.swift
@@ -9,12 +9,13 @@ import UIKit
 
 class WaveFormImageView: UIImageView {
 
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.frame.size.width = CGFloat(FP_INFINITE)
+        self.contentMode = .left
     }
-    */
-
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 }


### PR DESCRIPTION
- 음원 파형 이미지 두번째 화면에 띄움
- 재생 중 파형 이미지를 나타내는 뷰 따로 파일로 분리
- 현재 재생 지점을 표시하는 세로줄을 포함한 뷰 따로 파일로 분리

